### PR TITLE
update Security Policy TLV to two bytes of flags

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -3579,7 +3579,7 @@ void
 SpinelNCPInstance::set_prop_DatasetSecPolicyFlags(const boost::any &value, CallbackWithStatus cb)
 {
 	ThreadDataset::SecurityPolicy policy = mLocalDataset.mSecurityPolicy.get();
-	policy.mFlags = static_cast<uint8_t>(any_to_int(value));
+	policy.mFlags = static_cast<uint16_t>(any_to_int(value));
 	mLocalDataset.mSecurityPolicy = policy;
 	cb(kWPANTUNDStatus_Ok);
 }

--- a/src/ncp-spinel/SpinelNCPThreadDataset.cpp
+++ b/src/ncp-spinel/SpinelNCPThreadDataset.cpp
@@ -433,7 +433,7 @@ ThreadDataset::parse_dataset_entry(const uint8_t *data_in, spinel_size_t data_le
 				value_len,
 				(
 					SPINEL_DATATYPE_UINT16_S
-					SPINEL_DATATYPE_UINT8_S
+					SPINEL_DATATYPE_UINT16_S
 				),
 				&sec_policy.mKeyRotationTime,
 				&sec_policy.mFlags
@@ -674,7 +674,7 @@ ThreadDataset::convert_to_spinel_frame(Data &frame, bool include_value)
 				SPINEL_DATATYPE_STRUCT_S(
 					SPINEL_DATATYPE_UINT_PACKED_S
 					SPINEL_DATATYPE_UINT16_S
-					SPINEL_DATATYPE_UINT8_S
+					SPINEL_DATATYPE_UINT16_S
 				),
 				SPINEL_PROP_DATASET_SECURITY_POLICY,
 				mSecurityPolicy.get().mKeyRotationTime,

--- a/src/ncp-spinel/SpinelNCPThreadDataset.h
+++ b/src/ncp-spinel/SpinelNCPThreadDataset.h
@@ -51,7 +51,7 @@ public:
 
 	struct SecurityPolicy {
 		uint16_t mKeyRotationTime;
-		uint8_t  mFlags;
+		uint16_t mFlags;
 	};
 
 	ThreadDataset(void) { clear(); }


### PR DESCRIPTION
This PR changes Security Policy TLV's flags from single byte to 2 bytes, which is defined in Thread 1.2.