### PR TITLE
setprop Thread:Config:ReferenceDevice

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -4061,58 +4061,6 @@ SpinelNCPInstance::set_prop_ThreadDomainPrefix(const boost::any &value, Callback
 }
 
 void
-SpinelNCPInstance::set_prop_ThreadConfigDuaResponse(const boost::any &value, CallbackWithStatus cb)
-{
-	Data packet = any_to_data(value);
-
-	if (packet.size() >= sizeof(spinel_eui64_t) + sizeof(uint8_t)) {
-		spinel_eui64_t mliid;
-		uint8_t status;
-
-		memcpy(&mliid, packet.data(), sizeof(spinel_eui64_t));
-		packet.pop_front(sizeof(spinel_eui64_t));
-		status = packet[0];
-
-		start_new_task(SpinelNCPTaskSendCommand::Factory(this)
-				.set_callback(cb)
-				.add_command(SpinelPackData(
-						SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_EUI64_S SPINEL_DATATYPE_UINT8_S),
-						SPINEL_PROP_THREAD_REFERENCE_DEVICE_DUA_RSP,
-						&mliid,
-						status
-						))
-				.finish()
-				);
-	} else {
-		cb(kWPANTUNDStatus_InvalidArgument);
-	}
-}
-
-void
-SpinelNCPInstance::set_prop_ThreadConfigMlrResponse(const boost::any &value, CallbackWithStatus cb)
-{
-	Data packet = any_to_data(value);
-
-	if (packet.size() >= sizeof(uint8_t)) {
-		uint8_t status;
-
-		status = packet[0];
-
-		start_new_task(SpinelNCPTaskSendCommand::Factory(this)
-				.set_callback(cb)
-				.add_command(SpinelPackData(
-						SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S),
-						SPINEL_PROP_THREAD_REFERENCE_DEVICE_MLR_RSP,
-						status
-						))
-				.finish()
-				);
-	} else {
-		cb(kWPANTUNDStatus_InvalidArgument);
-	}
-}
-
-void
 SpinelNCPInstance::set_prop_ThreadConfigReferenceDevice(const boost::any &value, CallbackWithStatus cb)
 {
 	Data packet = any_to_data(value);

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -3572,12 +3572,6 @@ SpinelNCPInstance::regsiter_all_set_handlers(void)
 		kWPANTUNDProperty_ThreadDomainPrefix,
 		boost::bind(&SpinelNCPInstance::set_prop_ThreadDomainPrefix, this, _1, _2));
 	register_set_handler(
-		kWPANTUNDProperty_ThreadConfigDuaResponse,
-		boost::bind(&SpinelNCPInstance::set_prop_ThreadConfigDuaResponse, this, _1, _2));
-	register_set_handler(
-		kWPANTUNDProperty_ThreadConfigMlrResponse,
-		boost::bind(&SpinelNCPInstance::set_prop_ThreadConfigMlrResponse, this, _1, _2));
-	register_set_handler(
 		kWPANTUNDProperty_ThreadConfigReferenceDevice,
 		boost::bind(&SpinelNCPInstance::set_prop_ThreadConfigReferenceDevice, this, _1, _2));
 	register_set_handler(

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -3578,6 +3578,9 @@ SpinelNCPInstance::regsiter_all_set_handlers(void)
 		kWPANTUNDProperty_ThreadConfigMlrResponse,
 		boost::bind(&SpinelNCPInstance::set_prop_ThreadConfigMlrResponse, this, _1, _2));
 	register_set_handler(
+		kWPANTUNDProperty_ThreadConfigReferenceDevice,
+		boost::bind(&SpinelNCPInstance::set_prop_ThreadConfigReferenceDevice, this, _1, _2));
+	register_set_handler(
 		kWPANTUNDProperty_BbrSequenceNumber,
 		boost::bind(&SpinelNCPInstance::set_prop_BbrSequenceNumber, this, _1, _2));
 	register_set_handler(
@@ -4101,6 +4104,35 @@ SpinelNCPInstance::set_prop_ThreadConfigMlrResponse(const boost::any &value, Cal
 						SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S),
 						SPINEL_PROP_THREAD_REFERENCE_DEVICE_MLR_RSP,
 						status
+						))
+				.finish()
+				);
+	} else {
+		cb(kWPANTUNDStatus_InvalidArgument);
+	}
+}
+
+void
+SpinelNCPInstance::set_prop_ThreadConfigReferenceDevice(const boost::any &value, CallbackWithStatus cb)
+{
+	Data packet = any_to_data(value);
+
+	if (packet.size() >= sizeof(uint8_t)) {
+		uint8_t cmd;
+
+		cmd = packet[0];
+		packet.pop_front(1);
+
+		syslog(LOG_INFO, "Config Reference Device: cmd=%02x payload=%d", cmd, packet.size());
+
+		start_new_task(SpinelNCPTaskSendCommand::Factory(this)
+				.set_callback(cb)
+				.add_command(SpinelPackData(
+						SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_DATA_S),
+						SPINEL_PROP_THREAD_REFERENCE_DEVICE_CONFIG,
+						cmd, 
+						packet.data(),
+						packet.size()
 						))
 				.finish()
 				);

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -331,8 +331,6 @@ private:
 	void set_prop_DatasetCommand(const boost::any &value, CallbackWithStatus cb);
 
 	void set_prop_ThreadDomainPrefix(const boost::any &value, CallbackWithStatus cb);
-	void set_prop_ThreadConfigDuaResponse(const boost::any &value, CallbackWithStatus cb);
-	void set_prop_ThreadConfigMlrResponse(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_ThreadConfigReferenceDevice(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_BbrSequenceNumber(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_BbrReregistrationDelay(const boost::any &value, CallbackWithStatus cb);

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -333,6 +333,7 @@ private:
 	void set_prop_ThreadDomainPrefix(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_ThreadConfigDuaResponse(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_ThreadConfigMlrResponse(const boost::any &value, CallbackWithStatus cb);
+	void set_prop_ThreadConfigReferenceDevice(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_BbrSequenceNumber(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_BbrReregistrationDelay(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_BbrMlrTimeout(const boost::any &value, CallbackWithStatus cb);

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -130,6 +130,7 @@
 #define kWPANTUNDProperty_ThreadConfigFilterALOCAddresses       "Thread:Config:FilterALOCAddresses"
 #define kWPANTUNDProperty_ThreadConfigDuaResponse               "Thread:Config:DuaResponse"
 #define kWPANTUNDProperty_ThreadConfigMlrResponse               "Thread:Config:MlrResponse"
+#define kWPANTUNDProperty_ThreadConfigReferenceDevice           "Thread:Config:ReferenceDevice"
 #define kWPANTUNDProperty_ThreadRouterUpgradeThreshold          "Thread:RouterUpgradeThreshold"
 #define kWPANTUNDProperty_ThreadRouterDowngradeThreshold        "Thread:RouterDowngradeThreshold"
 #define kWPANTUNDProperty_ThreadActiveDataset                   "Thread:ActiveDataset"

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -128,8 +128,6 @@
 #define kWPANTUNDProperty_ThreadRouterRoleEnabled               "Thread:RouterRole:Enabled"
 #define kWPANTUNDProperty_ThreadConfigFilterRLOCAddresses       "Thread:Config:FilterRLOCAddresses"
 #define kWPANTUNDProperty_ThreadConfigFilterALOCAddresses       "Thread:Config:FilterALOCAddresses"
-#define kWPANTUNDProperty_ThreadConfigDuaResponse               "Thread:Config:DuaResponse"
-#define kWPANTUNDProperty_ThreadConfigMlrResponse               "Thread:Config:MlrResponse"
 #define kWPANTUNDProperty_ThreadConfigReferenceDevice           "Thread:Config:ReferenceDevice"
 #define kWPANTUNDProperty_ThreadRouterUpgradeThreshold          "Thread:RouterUpgradeThreshold"
 #define kWPANTUNDProperty_ThreadRouterDowngradeThreshold        "Thread:RouterDowngradeThreshold"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1831,8 +1831,8 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_NDPROXY_TABLE";
         break;
 
-    case SPINEL_PROP_THREAD_REFERENCE_DEVICE_DUA_RSP:
-        ret = "PROP_THREAD_REFERENCE_DEVICE_DUA_RSP";
+    case SPINEL_PROP_THREAD_REFERENCE_DEVICE_CONFIG:
+        ret = "SPINEL_PROP_THREAD_REFERENCE_DEVICE_CONFIG";
         break;
 
     case SPINEL_PROP_MESHCOP_JOINER_STATE:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -2903,15 +2903,25 @@ typedef enum
     SPINEL_PROP_THREAD_REFERENCE_DEVICE_DUA_RSP = SPINEL_PROP_THREAD_EXT__BEGIN + 73,
 
     /// Configure BBR's MLR rsp for next MLR.req from specified device, only for certification purpose.
-    /** Format: [EL]] - Write only
+    /** Format: [L]] - Write only
      *
      * Data per item is:
      *
-     *  `E`: Mesh Local IID of the specified device.
      *  `L`: Status value to respond with
      *
      */
     SPINEL_PROP_THREAD_REFERENCE_DEVICE_MLR_RSP = SPINEL_PROP_THREAD_EXT__BEGIN + 74,
+
+    /// Configure reference device for certification purpose.
+    /** Format: [CD]] - Write only
+     *
+     * Data per item is:
+     *
+     *  `C`: Mesh Local IID of the specified device.
+     *  `D`: Status value to respond with
+     *
+     */
+    SPINEL_PROP_THREAD_REFERENCE_DEVICE_CONFIG = SPINEL_PROP_THREAD_EXT__BEGIN + 75,
 
     SPINEL_PROP_THREAD_EXT__END = 0x1600,
 

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -2917,8 +2917,8 @@ typedef enum
      *
      * Data per item is:
      *
-     *  `C`: Mesh Local IID of the specified device.
-     *  `D`: Status value to respond with
+     *  `C`: Command
+     *  `D`: Data
      *
      */
     SPINEL_PROP_THREAD_REFERENCE_DEVICE_CONFIG = SPINEL_PROP_THREAD_EXT__BEGIN + 75,

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -2890,28 +2890,6 @@ typedef enum
      */
     SPINEL_PROP_THREAD_NDPROXY_TABLE = SPINEL_PROP_THREAD_EXT__BEGIN + 72,
 
-    /// Configure BBR's DUA rsp for next DUA.req from specified device, only for certification purpose.
-    /** Format: [EL]] - Write only
-     *
-     * Data per item is:
-     *
-     *  `E`: Mesh Local IID of the specified device.
-     *  `L`: Status value to respond with
-     *
-     */
-
-    SPINEL_PROP_THREAD_REFERENCE_DEVICE_DUA_RSP = SPINEL_PROP_THREAD_EXT__BEGIN + 73,
-
-    /// Configure BBR's MLR rsp for next MLR.req from specified device, only for certification purpose.
-    /** Format: [L]] - Write only
-     *
-     * Data per item is:
-     *
-     *  `L`: Status value to respond with
-     *
-     */
-    SPINEL_PROP_THREAD_REFERENCE_DEVICE_MLR_RSP = SPINEL_PROP_THREAD_EXT__BEGIN + 74,
-
     /// Configure reference device for certification purpose.
     /** Format: [CD]] - Write only
      *
@@ -2921,7 +2899,7 @@ typedef enum
      *  `D`: Data
      *
      */
-    SPINEL_PROP_THREAD_REFERENCE_DEVICE_CONFIG = SPINEL_PROP_THREAD_EXT__BEGIN + 75,
+    SPINEL_PROP_THREAD_REFERENCE_DEVICE_CONFIG = SPINEL_PROP_THREAD_EXT__BEGIN + 73,
 
     SPINEL_PROP_THREAD_EXT__END = 0x1600,
 


### PR DESCRIPTION
Add `setprop Thread:Config:ReferenceDevice` to configure reference device for certification purposes. 
`wpantund` does not care what `Cmd` and `Data` means but only pass it to OT-NCP. 

TODO:
- [x] Remove `Thread:Config:DuaResponse`
- [x] Remove `Thread:Config:MlrResponse`